### PR TITLE
Add test verb to mvn command

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 17.0.x
       - name: Pitest
-        run: mvn org.pitest:pitest-maven:mutationCoverage
+        run: mvn test org.pitest:pitest-maven:mutationCoverage
       - name: Upload Pitest to Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION

# Overview

This fixes the PITest GitHub action, which was failing because the `run` definition left out `test` from the `mvn` command.


## Reminders (delete this section before merging or as code is merged)
- [ ] Explicitly link to this pull request each issue that it closes
- [ ] Assign one and ideally two reviewers to review this pull request. 
- [ ] Reviewers should not just approve with "Looks good!" Instead, reviewers should carefully go through the code and use GitHub's reviewer interface to ask questions, make comments, and suggest changes.
